### PR TITLE
Fix NumPy check for recent versions under Python 3

### DIFF
--- a/python.py
+++ b/python.py
@@ -97,9 +97,16 @@ def CheckNumPy(context):
 #undef _DEBUG
 #include "Python.h"
 #include "numpy/arrayobject.h"
+#if PY_MAJOR_VERSION == 2
 void doImport() {
   import_array();
 }
+#else
+void * doImport() {
+  import_array();
+  return nullptr;
+}
+#endif
 int main()
 {
   int result = 0;


### PR DESCRIPTION
NumPy's import_array macro now returns with a value when run under Python 3.

This won't work without changes to SCons to support Python 3 (as @nbecker has done), but it's a step in the right direction.
